### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Latest Version](https://pypip.in/version/pyearcal/badge.svg)](https://pypi.python.org/pypi/pyearcal/)
+[![Latest Version](https://img.shields.io/pypi/v/pyearcal.svg)](https://pypi.python.org/pypi/pyearcal/)
 
 pyearcal
 ========


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyearcal))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyearcal`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.